### PR TITLE
feat(frontend): add pagination to list panels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: 1.26.1
+  GO_VERSION: 1.26.2
   PLATO_VULN_REPORT_ROOT: .cache/vuln/reports
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -98,12 +98,12 @@ Router logic is organized by domain in `backend/internal/httpapi`:
 ### Prerequisites
 
 - Node.js LTS and npm or pnpm
-- Go `1.26.1`
+- Go `1.26.2`
 
 Toolchain policy:
 - Plato enforces the exact Go version from `backend/go.mod` for reproducible local and CI checks
-- `make check` runs `scripts/check_go_toolchain.sh` and fails fast with a clear mismatch message when local Go is not `1.26.1`
-- For containerized local development, use a base image pinned to `golang:1.26.1`
+- `make check` runs `scripts/check_go_toolchain.sh` and fails fast with a clear mismatch message when local Go is not `1.26.2`
+- For containerized local development, use a base image pinned to `golang:1.26.2`
 
 ### Run in development
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,3 +1,3 @@
 module plato/backend
 
-go 1.26.1
+go 1.26.2

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -30,6 +30,18 @@ function sectionByHeading(name: RegExp): ReturnType<typeof within> {
   return within(section as HTMLElement)
 }
 
+function buildPersonRows(count: number) {
+  return Array.from({ length: count }, (_, index) => {
+    const personNumber = index + 1
+    return {
+      id: `person_${personNumber}`,
+      organisation_id: "org_1",
+      name: `Person ${personNumber}`,
+      employment_pct: 100
+    }
+  })
+}
+
 describe("App focused behaviors", () => {
   it("renders the title", async () => {
     render(<App />)
@@ -127,6 +139,39 @@ describe("App focused behaviors", () => {
     expect(report.getByRole("columnheader", { name: /^project load hours$/i })).toBeInTheDocument()
     expect(report.getByRole("columnheader", { name: /^project estimation hours$/i })).toBeInTheDocument()
     expect(report.getByRole("columnheader", { name: /^project completion %$/i })).toBeInTheDocument()
+  })
+
+  it("paginates person rows and keeps selection across pages", async () => {
+    buildMockAPI({
+      persons: buildPersonRows(12)
+    })
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("option", { name: "Alpha Org" }).length).toBeGreaterThan(0)
+    })
+
+    const personsPanel = sectionByHeading(/^persons$/i)
+    expect(personsPanel.getByRole("cell", { name: "Person 1" })).toBeInTheDocument()
+    expect(personsPanel.getByRole("cell", { name: "Person 10" })).toBeInTheDocument()
+    expect(personsPanel.queryByRole("cell", { name: "Person 11" })).not.toBeInTheDocument()
+    expect(personsPanel.getByText("Showing 1-10 of 12")).toBeInTheDocument()
+    expect(personsPanel.getByText("Page 1 of 2")).toBeInTheDocument()
+
+    fireEvent.click(personsPanel.getByRole("checkbox", { name: /^select all persons$/i }))
+    expect(personsPanel.getByText("12 items selected")).toBeInTheDocument()
+
+    fireEvent.click(personsPanel.getByRole("button", { name: /next page/i }))
+    expect(personsPanel.getByRole("cell", { name: "Person 11" })).toBeInTheDocument()
+    expect(personsPanel.getByRole("cell", { name: "Person 12" })).toBeInTheDocument()
+    expect(personsPanel.getByRole("checkbox", { name: /select person person 11/i })).toBeChecked()
+    expect(personsPanel.queryByRole("cell", { name: "Person 1" })).not.toBeInTheDocument()
+
+    fireEvent.change(personsPanel.getByLabelText(/items per page/i), { target: { value: "20" } })
+    expect(personsPanel.getByRole("cell", { name: "Person 1" })).toBeInTheDocument()
+    expect(personsPanel.getByRole("cell", { name: "Person 12" })).toBeInTheDocument()
+    expect(personsPanel.queryByText(/Page 1 of/i)).not.toBeInTheDocument()
   })
 
   it("runs organisation and project reports and renders project columns", async () => {

--- a/frontend/src/hooks/usePagination.test.ts
+++ b/frontend/src/hooks/usePagination.test.ts
@@ -1,0 +1,87 @@
+import { act, renderHook } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { usePagination } from "./usePagination"
+
+function numberItems(count: number): number[] {
+  return Array.from({ length: count }, (_, index) => index + 1)
+}
+
+describe("usePagination", () => {
+  it("uses ten items per page by default", () => {
+    const items = numberItems(23)
+    const { result } = renderHook(() => usePagination(items))
+
+    expect(result.current.pageSize).toBe(10)
+    expect(result.current.currentPage).toBe(1)
+    expect(result.current.totalPages).toBe(3)
+    expect(result.current.visibleItems).toEqual(numberItems(10))
+    expect(result.current.startItemNumber).toBe(1)
+    expect(result.current.endItemNumber).toBe(10)
+    expect(result.current.hasPreviousPage).toBe(false)
+    expect(result.current.hasNextPage).toBe(true)
+  })
+
+  it("moves between pages and clamps invalid targets", () => {
+    const items = numberItems(23)
+    const { result } = renderHook(() => usePagination(items))
+
+    act(() => result.current.goToNextPage())
+    expect(result.current.currentPage).toBe(2)
+    expect(result.current.visibleItems).toEqual(numberItems(20).slice(10, 20))
+    expect(result.current.hasPreviousPage).toBe(true)
+
+    act(() => result.current.goToPreviousPage())
+    expect(result.current.currentPage).toBe(1)
+
+    act(() => result.current.goToPage(99))
+    expect(result.current.currentPage).toBe(3)
+
+    act(() => result.current.goToPage(Number.NaN))
+    expect(result.current.currentPage).toBe(1)
+  })
+
+  it("changes page size, resets to page one, and supports all items", () => {
+    const items = numberItems(23)
+    const { result } = renderHook(() => usePagination(items, { defaultPageSize: 20 }))
+
+    expect(result.current.pageSize).toBe(20)
+    expect(result.current.visibleItems).toEqual(numberItems(20))
+
+    act(() => result.current.goToNextPage())
+    expect(result.current.currentPage).toBe(2)
+
+    act(() => result.current.changePageSize(50))
+    expect(result.current.currentPage).toBe(1)
+    expect(result.current.pageSize).toBe(50)
+    expect(result.current.visibleItems).toEqual(items)
+
+    act(() => result.current.changePageSize("all"))
+    expect(result.current.currentPage).toBe(1)
+    expect(result.current.totalPages).toBe(1)
+    expect(result.current.isPaginated).toBe(false)
+    expect(result.current.visibleItems).toEqual(items)
+  })
+
+  it("adjusts the current page when items are removed", () => {
+    const { result, rerender } = renderHook(
+      ({ items }) => usePagination(items),
+      { initialProps: { items: numberItems(21) } }
+    )
+
+    act(() => result.current.goToPage(3))
+    expect(result.current.currentPage).toBe(3)
+    expect(result.current.visibleItems).toEqual([21])
+
+    rerender({ items: numberItems(15) })
+    expect(result.current.currentPage).toBe(2)
+    expect(result.current.visibleItems).toEqual(numberItems(15).slice(10, 15))
+
+    rerender({ items: [] })
+    expect(result.current.currentPage).toBe(1)
+    expect(result.current.totalPages).toBe(1)
+    expect(result.current.startItemNumber).toBe(0)
+    expect(result.current.endItemNumber).toBe(0)
+    expect(result.current.visibleItems).toEqual([])
+  })
+
+})

--- a/frontend/src/hooks/usePagination.ts
+++ b/frontend/src/hooks/usePagination.ts
@@ -1,0 +1,121 @@
+import { useCallback, useMemo, useState } from "react"
+
+export const DEFAULT_PAGE_SIZE = 10
+
+export const PAGE_SIZE_OPTIONS = [10, 20, 50, 100, "all"] as const
+
+export type PageSize = typeof PAGE_SIZE_OPTIONS[number]
+
+type UsePaginationOptions = {
+  defaultPageSize?: PageSize
+}
+
+type UsePaginationResult<T> = {
+  visibleItems: T[]
+  currentPage: number
+  pageSize: PageSize
+  totalPages: number
+  totalItems: number
+  startItemNumber: number
+  endItemNumber: number
+  isPaginated: boolean
+  hasPreviousPage: boolean
+  hasNextPage: boolean
+  goToPage: (page: number) => void
+  goToNextPage: () => void
+  goToPreviousPage: () => void
+  changePageSize: (pageSize: PageSize) => void
+}
+
+function pageCountFor(totalItems: number, pageSize: PageSize): number {
+  if (totalItems === 0 || pageSize === "all") {
+    return 1
+  }
+  return Math.ceil(totalItems / pageSize)
+}
+
+function clampPage(page: number, totalPages: number): number {
+  const wholePage = Math.trunc(page)
+  const safePage = Number.isFinite(wholePage) ? wholePage : 1
+  return Math.min(Math.max(safePage, 1), totalPages)
+}
+
+export function usePagination<T>(
+  items: T[],
+  options: UsePaginationOptions = {}
+): UsePaginationResult<T> {
+  const {
+    defaultPageSize = DEFAULT_PAGE_SIZE
+  } = options
+  const [currentPageState, setCurrentPageState] = useState(1)
+  const [pageSize, setPageSize] = useState<PageSize>(defaultPageSize)
+  const totalItems = items.length
+  const totalPages = useMemo(
+    () => pageCountFor(totalItems, pageSize),
+    [pageSize, totalItems]
+  )
+  const currentPage = clampPage(currentPageState, totalPages)
+
+  const firstVisibleIndex = useMemo(() => {
+    if (pageSize === "all" || totalItems === 0) {
+      return 0
+    }
+    return (currentPage - 1) * pageSize
+  }, [currentPage, pageSize, totalItems])
+
+  // Callers should memoize derived arrays if they need to avoid reference-based slicing work.
+  const visibleItems = useMemo(() => {
+    if (pageSize === "all") {
+      return items
+    }
+
+    const endIndex = firstVisibleIndex + pageSize
+    return items.slice(firstVisibleIndex, endIndex)
+  }, [firstVisibleIndex, items, pageSize])
+
+  const startItemNumber = totalItems === 0 ? 0 : firstVisibleIndex + 1
+  const endItemNumber = totalItems === 0 ? 0 : firstVisibleIndex + visibleItems.length
+  const isPaginated = pageSize !== "all" && totalPages > 1
+  const hasPreviousPage = isPaginated && currentPage > 1
+  const hasNextPage = isPaginated && currentPage < totalPages
+
+  const goToPage = useCallback((page: number) => {
+    setCurrentPageState(clampPage(page, totalPages))
+  }, [totalPages])
+
+  const goToNextPage = useCallback(() => {
+    setCurrentPageState((previousPage) => {
+      const safePreviousPage = clampPage(previousPage, totalPages)
+      return clampPage(safePreviousPage + 1, totalPages)
+    })
+  }, [totalPages])
+
+  const goToPreviousPage = useCallback(() => {
+    setCurrentPageState((previousPage) => {
+      const safePreviousPage = clampPage(previousPage, totalPages)
+      return clampPage(safePreviousPage - 1, totalPages)
+    })
+  }, [totalPages])
+
+  const changePageSize = useCallback((nextPageSize: PageSize) => {
+    setPageSize(nextPageSize)
+    setCurrentPageState(1)
+  }, [])
+
+  return {
+    visibleItems,
+    currentPage,
+    pageSize,
+    totalPages,
+    totalItems,
+    startItemNumber,
+    endItemNumber,
+    isPaginated,
+    hasPreviousPage,
+    hasNextPage,
+    goToPage,
+    goToNextPage,
+    goToPreviousPage,
+    changePageSize
+  }
+}

--- a/frontend/src/panels/AllocationsPanel.tsx
+++ b/frontend/src/panels/AllocationsPanel.tsx
@@ -1,5 +1,7 @@
 import type { Dispatch, FormEvent, RefObject, SetStateAction } from "react"
 import { normalizeAllocationTargetID, normalizeAllocationTargetType } from "../app/helpers"
+import { usePagination } from "../hooks/usePagination"
+import { PaginationControls } from "./PaginationControls"
 import type {
   Allocation,
   AllocationFormState,
@@ -71,6 +73,8 @@ export function AllocationsPanel(props: AllocationsPanelProps) {
   const groupsByID = new Map(groups.map((group) => [group.id, group]))
   const personsByID = new Map(persons.map((person) => [person.id, person]))
   const projectsByID = new Map(projects.map((project) => [project.id, project]))
+  const allocationsPagination = usePagination(allocations)
+  const visibleAllocations = allocationsPagination.visibleItems
 
   return (
     <section className="panel">
@@ -225,7 +229,7 @@ export function AllocationsPanel(props: AllocationsPanelProps) {
           </tr>
         </thead>
         <tbody>
-          {allocations.map((allocation) => {
+          {visibleAllocations.map((allocation) => {
             const targetType = normalizeAllocationTargetType(allocation)
             const targetID = normalizeAllocationTargetID(allocation)
             const targetLabel = targetType === "group"
@@ -265,8 +269,29 @@ export function AllocationsPanel(props: AllocationsPanelProps) {
               </tr>
             )
           })}
+          {allocations.length === 0 && (
+            <tr>
+              <td colSpan={7}>No items to display</td>
+            </tr>
+          )}
         </tbody>
       </table>
+      <PaginationControls
+        ariaLabel="Allocations pagination"
+        currentPage={allocationsPagination.currentPage}
+        endItemNumber={allocationsPagination.endItemNumber}
+        hasNextPage={allocationsPagination.hasNextPage}
+        hasPreviousPage={allocationsPagination.hasPreviousPage}
+        isPaginated={allocationsPagination.isPaginated}
+        pageSize={allocationsPagination.pageSize}
+        selectedItemCount={selectedAllocationIDs.length}
+        startItemNumber={allocationsPagination.startItemNumber}
+        totalItems={allocationsPagination.totalItems}
+        totalPages={allocationsPagination.totalPages}
+        onNextPage={allocationsPagination.goToNextPage}
+        onPageSizeChange={allocationsPagination.changePageSize}
+        onPreviousPage={allocationsPagination.goToPreviousPage}
+      />
     </section>
   )
 }

--- a/frontend/src/panels/GroupsPanel.tsx
+++ b/frontend/src/panels/GroupsPanel.tsx
@@ -1,5 +1,7 @@
 import type { Dispatch, FormEvent, RefObject, SetStateAction } from "react"
 import type { Group, GroupFormState, GroupMemberFormState, Person } from "../app/types"
+import { usePagination } from "../hooks/usePagination"
+import { PaginationControls } from "./PaginationControls"
 
 type GroupsPanelProps = {
   groupForm: GroupFormState
@@ -46,6 +48,8 @@ export function GroupsPanel(props: GroupsPanelProps) {
     onDeleteGroup
   } = props
   const personByID = new Map(persons.map((person) => [person.id, person]))
+  const groupsPagination = usePagination(groups)
+  const visibleGroups = groupsPagination.visibleItems
 
   return (
     <section className="panel">
@@ -143,7 +147,7 @@ export function GroupsPanel(props: GroupsPanelProps) {
           </tr>
         </thead>
         <tbody>
-          {groups.map((group) => (
+          {visibleGroups.map((group) => (
             <tr key={group.id}>
               <td>
                 <input
@@ -186,8 +190,29 @@ export function GroupsPanel(props: GroupsPanelProps) {
               </td>
             </tr>
           ))}
+          {groups.length === 0 && (
+            <tr>
+              <td colSpan={4}>No items to display</td>
+            </tr>
+          )}
         </tbody>
       </table>
+      <PaginationControls
+        ariaLabel="Groups pagination"
+        currentPage={groupsPagination.currentPage}
+        endItemNumber={groupsPagination.endItemNumber}
+        hasNextPage={groupsPagination.hasNextPage}
+        hasPreviousPage={groupsPagination.hasPreviousPage}
+        isPaginated={groupsPagination.isPaginated}
+        pageSize={groupsPagination.pageSize}
+        selectedItemCount={selectedGroupIDs.length}
+        startItemNumber={groupsPagination.startItemNumber}
+        totalItems={groupsPagination.totalItems}
+        totalPages={groupsPagination.totalPages}
+        onNextPage={groupsPagination.goToNextPage}
+        onPageSizeChange={groupsPagination.changePageSize}
+        onPreviousPage={groupsPagination.goToPreviousPage}
+      />
     </section>
   )
 }

--- a/frontend/src/panels/HolidaysUnavailabilityPanel.tsx
+++ b/frontend/src/panels/HolidaysUnavailabilityPanel.tsx
@@ -1,4 +1,6 @@
 import type { Dispatch, FormEvent, SetStateAction } from "react"
+import { usePagination } from "../hooks/usePagination"
+import { PaginationControls } from "./PaginationControls"
 import type {
   AvailabilityScope,
   AvailabilityUnitScope,
@@ -39,6 +41,77 @@ type HolidaysUnavailabilityPanelProps = {
   selectedGroupPersonUnavailability: PersonUnavailability[]
 }
 
+type UnavailabilityTableProps = {
+  entries: PersonUnavailability[]
+  persons: Person[]
+  isOverallocatedPersonID: (personID: string) => boolean
+  onDeletePersonUnavailability: (entry: PersonUnavailability) => void
+}
+
+function UnavailabilityTable(props: UnavailabilityTableProps) {
+  const {
+    entries,
+    persons,
+    isOverallocatedPersonID,
+    onDeletePersonUnavailability
+  } = props
+  const personByID = new Map(persons.map((person) => [person.id, person]))
+  const pagination = usePagination(entries)
+  const visibleEntries = pagination.visibleItems
+
+  return (
+    <>
+      <table>
+        <thead>
+          <tr>
+            <th>Person</th>
+            <th>Date</th>
+            <th>Hours</th>
+            <th />
+          </tr>
+        </thead>
+        <tbody>
+          {visibleEntries.map((entry) => {
+            const person = personByID.get(entry.person_id)
+            return (
+              <tr key={entry.id}>
+                <td className={isOverallocatedPersonID(entry.person_id) ? "person-overallocated" : undefined}>
+                  {person?.name ?? entry.person_id}
+                </td>
+                <td>{entry.date}</td>
+                <td>{entry.hours}</td>
+                <td>
+                  <button type="button" onClick={() => onDeletePersonUnavailability(entry)}>Delete</button>
+                </td>
+              </tr>
+            )
+          })}
+          {entries.length === 0 && (
+            <tr>
+              <td colSpan={4}>No items to display</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+      <PaginationControls
+        ariaLabel="Unavailability pagination"
+        currentPage={pagination.currentPage}
+        endItemNumber={pagination.endItemNumber}
+        hasNextPage={pagination.hasNextPage}
+        hasPreviousPage={pagination.hasPreviousPage}
+        isPaginated={pagination.isPaginated}
+        pageSize={pagination.pageSize}
+        startItemNumber={pagination.startItemNumber}
+        totalItems={pagination.totalItems}
+        totalPages={pagination.totalPages}
+        onNextPage={pagination.goToNextPage}
+        onPageSizeChange={pagination.changePageSize}
+        onPreviousPage={pagination.goToPreviousPage}
+      />
+    </>
+  )
+}
+
 export function HolidaysUnavailabilityPanel(props: HolidaysUnavailabilityPanelProps) {
   const {
     availabilityScope,
@@ -66,7 +139,9 @@ export function HolidaysUnavailabilityPanel(props: HolidaysUnavailabilityPanelPr
     groups,
     selectedGroupPersonUnavailability
   } = props
-  const personByID = new Map(persons.map((person) => [person.id, person]))
+  const activeUnavailabilityEntries = availabilityScope === "group"
+    ? selectedGroupPersonUnavailability
+    : personUnavailability
 
   return (
     <section className="panel">
@@ -141,30 +216,12 @@ export function HolidaysUnavailabilityPanel(props: HolidaysUnavailabilityPanelPr
             <button type="submit">{availabilityUnitScope === "hours" ? "Add org unavailability" : "Add org member unavailability"}</button>
           </form>
 
-          <table>
-            <thead>
-              <tr>
-                <th>Person</th>
-                <th>Date</th>
-                <th>Hours</th>
-                <th />
-              </tr>
-            </thead>
-            <tbody>
-              {personUnavailability.map((entry) => (
-                <tr key={entry.id}>
-                  <td className={isOverallocatedPersonID(entry.person_id) ? "person-overallocated" : undefined}>
-                    {personByID.get(entry.person_id)?.name ?? entry.person_id}
-                  </td>
-                  <td>{entry.date}</td>
-                  <td>{entry.hours}</td>
-                  <td>
-                    <button type="button" onClick={() => onDeletePersonUnavailability(entry)}>Delete</button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <UnavailabilityTable
+            entries={activeUnavailabilityEntries}
+            persons={persons}
+            isOverallocatedPersonID={isOverallocatedPersonID}
+            onDeletePersonUnavailability={onDeletePersonUnavailability}
+          />
         </>
       )}
 
@@ -223,33 +280,12 @@ export function HolidaysUnavailabilityPanel(props: HolidaysUnavailabilityPanelPr
             <button type="submit">{availabilityUnitScope === "hours" ? "Add person unavailability" : "Add person unavailability entries"}</button>
           </form>
 
-          <table>
-            <thead>
-              <tr>
-                <th>Person</th>
-                <th>Date</th>
-                <th>Hours</th>
-                <th />
-              </tr>
-            </thead>
-            <tbody>
-              {personUnavailability.map((entry) => {
-                const person = personByID.get(entry.person_id)
-                return (
-                  <tr key={entry.id}>
-                    <td className={isOverallocatedPersonID(entry.person_id) ? "person-overallocated" : undefined}>
-                      {person?.name ?? entry.person_id}
-                    </td>
-                    <td>{entry.date}</td>
-                    <td>{entry.hours}</td>
-                    <td>
-                      <button type="button" onClick={() => onDeletePersonUnavailability(entry)}>Delete</button>
-                    </td>
-                  </tr>
-                )
-              })}
-            </tbody>
-          </table>
+          <UnavailabilityTable
+            entries={activeUnavailabilityEntries}
+            persons={persons}
+            isOverallocatedPersonID={isOverallocatedPersonID}
+            onDeletePersonUnavailability={onDeletePersonUnavailability}
+          />
         </>
       )}
 
@@ -302,33 +338,12 @@ export function HolidaysUnavailabilityPanel(props: HolidaysUnavailabilityPanelPr
             <button type="submit">{availabilityUnitScope === "hours" ? "Add group unavailability" : "Add group unavailability entries"}</button>
           </form>
 
-          <table>
-            <thead>
-              <tr>
-                <th>Person</th>
-                <th>Date</th>
-                <th>Hours</th>
-                <th />
-              </tr>
-            </thead>
-            <tbody>
-              {selectedGroupPersonUnavailability.map((entry) => {
-                const person = personByID.get(entry.person_id)
-                return (
-                  <tr key={entry.id}>
-                    <td className={isOverallocatedPersonID(entry.person_id) ? "person-overallocated" : undefined}>
-                      {person?.name ?? entry.person_id}
-                    </td>
-                    <td>{entry.date}</td>
-                    <td>{entry.hours}</td>
-                    <td>
-                      <button type="button" onClick={() => onDeletePersonUnavailability(entry)}>Delete</button>
-                    </td>
-                  </tr>
-                )
-              })}
-            </tbody>
-          </table>
+          <UnavailabilityTable
+            entries={activeUnavailabilityEntries}
+            persons={persons}
+            isOverallocatedPersonID={isOverallocatedPersonID}
+            onDeletePersonUnavailability={onDeletePersonUnavailability}
+          />
         </>
       )}
     </section>

--- a/frontend/src/panels/PaginationControls.test.tsx
+++ b/frontend/src/panels/PaginationControls.test.tsx
@@ -1,0 +1,110 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import type { ComponentProps } from "react"
+import { describe, expect, it, vi } from "vitest"
+import { PaginationControls } from "./PaginationControls"
+import { DEFAULT_PAGE_SIZE } from "../hooks/usePagination"
+
+function renderControls(overrides: Partial<ComponentProps<typeof PaginationControls>> = {}) {
+  const props: ComponentProps<typeof PaginationControls> = {
+    ariaLabel: "Test pagination",
+    currentPage: 1,
+    endItemNumber: 10,
+    hasNextPage: true,
+    hasPreviousPage: false,
+    isPaginated: true,
+    pageSize: 10,
+    selectedItemCount: 2,
+    startItemNumber: 1,
+    totalItems: 25,
+    totalPages: 3,
+    onNextPage: vi.fn(),
+    onPageSizeChange: vi.fn(),
+    onPreviousPage: vi.fn(),
+    ...overrides
+  }
+
+  render(<PaginationControls {...props} />)
+  return props
+}
+
+describe("PaginationControls", () => {
+  it("renders page state, selection count, and navigation actions", () => {
+    const props = renderControls()
+
+    expect(screen.getByText("Showing 1-10 of 25")).toBeInTheDocument()
+    expect(screen.getByText("2 items selected")).toBeInTheDocument()
+    expect(screen.getByText("Page 1 of 3")).toHaveAttribute("aria-live", "polite")
+    expect(screen.getByRole("button", { name: /previous page/i })).toBeDisabled()
+    expect(screen.getByRole("button", { name: /next page/i })).toBeEnabled()
+
+    fireEvent.click(screen.getByRole("button", { name: /next page/i }))
+    expect(props.onNextPage).toHaveBeenCalledTimes(1)
+  })
+
+  it("calls the previous page action when previous is enabled", () => {
+    const props = renderControls({
+      currentPage: 2,
+      hasPreviousPage: true
+    })
+
+    const previousButton = screen.getByRole("button", { name: /previous page/i })
+    expect(previousButton).toBeEnabled()
+
+    fireEvent.click(previousButton)
+    expect(props.onPreviousPage).toHaveBeenCalledTimes(1)
+  })
+
+  it("changes page size with numeric and all options", () => {
+    const props = renderControls()
+    const selector = screen.getByLabelText(/items per page/i)
+
+    fireEvent.change(selector, { target: { value: "20" } })
+    expect(props.onPageSizeChange).toHaveBeenCalledWith(20)
+
+    fireEvent.change(selector, { target: { value: "all" } })
+    expect(props.onPageSizeChange).toHaveBeenCalledWith("all")
+
+    fireEvent.change(selector, { target: { value: "unsupported" } })
+    expect(props.onPageSizeChange).toHaveBeenCalledWith(DEFAULT_PAGE_SIZE)
+  })
+
+  it("shows the selector without navigation when all items fit", () => {
+    renderControls({
+      endItemNumber: 3,
+      hasNextPage: false,
+      isPaginated: false,
+      pageSize: "all",
+      selectedItemCount: 0,
+      totalItems: 3,
+      totalPages: 1
+    })
+
+    expect(screen.getByText("Showing 1-3 of 3")).toBeInTheDocument()
+    expect(screen.getByLabelText(/items per page/i)).toHaveValue("all")
+    expect(screen.queryByText(/items selected/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole("navigation", { name: /test pagination/i })).not.toBeInTheDocument()
+  })
+
+  it("hides every control for empty lists", () => {
+    const { container } = render(
+      <PaginationControls
+        ariaLabel="Empty pagination"
+        currentPage={1}
+        endItemNumber={0}
+        hasNextPage={false}
+        hasPreviousPage={false}
+        isPaginated={false}
+        pageSize={10}
+        selectedItemCount={0}
+        startItemNumber={0}
+        totalItems={0}
+        totalPages={1}
+        onNextPage={vi.fn()}
+        onPageSizeChange={vi.fn()}
+        onPreviousPage={vi.fn()}
+      />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/frontend/src/panels/PaginationControls.tsx
+++ b/frontend/src/panels/PaginationControls.tsx
@@ -1,0 +1,123 @@
+import { useId } from "react"
+import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS, type PageSize } from "../hooks/usePagination"
+
+type PaginationControlsProps = {
+  ariaLabel: string
+  currentPage: number
+  endItemNumber: number
+  hasNextPage: boolean
+  hasPreviousPage: boolean
+  isPaginated: boolean
+  pageSize: PageSize
+  selectedItemCount?: number
+  startItemNumber: number
+  totalItems: number
+  totalPages: number
+  onNextPage: () => void
+  onPageSizeChange: (pageSize: PageSize) => void
+  onPreviousPage: () => void
+}
+
+type NumericPageSize = Exclude<PageSize, "all">
+
+function optionValue(pageSize: PageSize): string {
+  return pageSize === "all" ? "all" : String(pageSize)
+}
+
+function isNumericPageSize(value: number): value is NumericPageSize {
+  return PAGE_SIZE_OPTIONS.some((option) => option === value)
+}
+
+function pageSizeFromValue(value: string): PageSize {
+  if (value === "all") {
+    return "all"
+  }
+
+  const numericValue = Number(value)
+  if (Number.isFinite(numericValue) && isNumericPageSize(numericValue)) {
+    return numericValue
+  }
+  return DEFAULT_PAGE_SIZE
+}
+
+function selectedItemLabel(selectedItemCount: number): string {
+  const noun = selectedItemCount === 1 ? "item" : "items"
+  return `${selectedItemCount} ${noun} selected`
+}
+
+export function PaginationControls(props: PaginationControlsProps) {
+  const {
+    ariaLabel,
+    currentPage,
+    endItemNumber,
+    hasNextPage,
+    hasPreviousPage,
+    isPaginated,
+    pageSize,
+    selectedItemCount = 0,
+    startItemNumber,
+    totalItems,
+    totalPages,
+    onNextPage,
+    onPageSizeChange,
+    onPreviousPage
+  } = props
+  const idBase = useId()
+
+  if (totalItems === 0) {
+    return null
+  }
+
+  const pageSizeSelectID = `${idBase}-page-size`
+  const pageSizeSelectValue = optionValue(pageSize)
+  const hasSelection = selectedItemCount > 0
+
+  return (
+    <div className="pagination-container">
+      <div className="pagination-summary">
+        <span>{`Showing ${startItemNumber}-${endItemNumber} of ${totalItems}`}</span>
+        {hasSelection && <span>{selectedItemLabel(selectedItemCount)}</span>}
+      </div>
+      <div className="pagination-actions">
+        <label className="pagination-page-size" htmlFor={pageSizeSelectID}>
+          Items per page:
+          <select
+            id={pageSizeSelectID}
+            value={pageSizeSelectValue}
+            onChange={(event) => onPageSizeChange(pageSizeFromValue(event.target.value))}
+          >
+            {PAGE_SIZE_OPTIONS.map((option) => (
+              <option key={option} value={optionValue(option)}>
+                {option === "all" ? "All" : option}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {isPaginated && (
+          <nav aria-label={ariaLabel} className="pagination-nav">
+            <button
+              type="button"
+              aria-label="Go to previous page"
+              disabled={!hasPreviousPage}
+              onClick={onPreviousPage}
+            >
+              Previous
+            </button>
+            <span aria-live="polite" className="pagination-page-indicator">
+              Page {currentPage} of {totalPages}
+            </span>
+            <button
+              type="button"
+              aria-label="Go to next page"
+              disabled={!hasNextPage}
+              onClick={onNextPage}
+            >
+              Next
+            </button>
+          </nav>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/panels/PersonsPanel.tsx
+++ b/frontend/src/panels/PersonsPanel.tsx
@@ -1,5 +1,7 @@
 import type { Dispatch, FormEvent, RefObject, SetStateAction } from "react"
 import type { Person, PersonFormState } from "../app/types"
+import { usePagination } from "../hooks/usePagination"
+import { PaginationControls } from "./PaginationControls"
 
 type PersonsPanelProps = {
   personForm: PersonFormState
@@ -36,6 +38,8 @@ export function PersonsPanel(props: PersonsPanelProps) {
     onDeletePerson
   } = props
   const selectedPersonIDSet = new Set(selectedPersonIDs)
+  const personsPagination = usePagination(persons)
+  const visiblePersons = personsPagination.visibleItems
 
   return (
     <section className="panel">
@@ -99,7 +103,7 @@ export function PersonsPanel(props: PersonsPanelProps) {
           </tr>
         </thead>
         <tbody>
-          {persons.map((person) => (
+          {visiblePersons.map((person) => (
             <tr key={person.id} className={isOverallocatedPersonID(person.id) ? "person-overallocated" : undefined}>
               <td>
                 <input
@@ -134,8 +138,29 @@ export function PersonsPanel(props: PersonsPanelProps) {
               </td>
             </tr>
           ))}
+          {persons.length === 0 && (
+            <tr>
+              <td colSpan={5}>No items to display</td>
+            </tr>
+          )}
         </tbody>
       </table>
+      <PaginationControls
+        ariaLabel="Persons pagination"
+        currentPage={personsPagination.currentPage}
+        endItemNumber={personsPagination.endItemNumber}
+        hasNextPage={personsPagination.hasNextPage}
+        hasPreviousPage={personsPagination.hasPreviousPage}
+        isPaginated={personsPagination.isPaginated}
+        pageSize={personsPagination.pageSize}
+        selectedItemCount={selectedPersonIDs.length}
+        startItemNumber={personsPagination.startItemNumber}
+        totalItems={personsPagination.totalItems}
+        totalPages={personsPagination.totalPages}
+        onNextPage={personsPagination.goToNextPage}
+        onPageSizeChange={personsPagination.changePageSize}
+        onPreviousPage={personsPagination.goToPreviousPage}
+      />
     </section>
   )
 }

--- a/frontend/src/panels/ProjectsPanel.tsx
+++ b/frontend/src/panels/ProjectsPanel.tsx
@@ -1,5 +1,7 @@
 import type { Dispatch, FormEvent, RefObject, SetStateAction } from "react"
 import type { Project, ProjectFormState } from "../app/types"
+import { usePagination } from "../hooks/usePagination"
+import { PaginationControls } from "./PaginationControls"
 
 type ProjectsPanelProps = {
   projectForm: ProjectFormState
@@ -34,6 +36,8 @@ export function ProjectsPanel(props: ProjectsPanelProps) {
     onDeleteProject
   } = props
   const selectedProjectIDSet = new Set(selectedProjectIDs)
+  const projectsPagination = usePagination(projects)
+  const visibleProjects = projectsPagination.visibleItems
 
   return (
     <section className="panel">
@@ -98,7 +102,7 @@ export function ProjectsPanel(props: ProjectsPanelProps) {
           </tr>
         </thead>
         <tbody>
-          {projects.map((project) => (
+          {visibleProjects.map((project) => (
             <tr key={project.id}>
               <td>
                 <input
@@ -128,8 +132,29 @@ export function ProjectsPanel(props: ProjectsPanelProps) {
               </td>
             </tr>
           ))}
+          {projects.length === 0 && (
+            <tr>
+              <td colSpan={6}>No items to display</td>
+            </tr>
+          )}
         </tbody>
       </table>
+      <PaginationControls
+        ariaLabel="Projects pagination"
+        currentPage={projectsPagination.currentPage}
+        endItemNumber={projectsPagination.endItemNumber}
+        hasNextPage={projectsPagination.hasNextPage}
+        hasPreviousPage={projectsPagination.hasPreviousPage}
+        isPaginated={projectsPagination.isPaginated}
+        pageSize={projectsPagination.pageSize}
+        selectedItemCount={selectedProjectIDs.length}
+        startItemNumber={projectsPagination.startItemNumber}
+        totalItems={projectsPagination.totalItems}
+        totalPages={projectsPagination.totalPages}
+        onNextPage={projectsPagination.goToNextPage}
+        onPageSizeChange={projectsPagination.changePageSize}
+        onPreviousPage={projectsPagination.goToPreviousPage}
+      />
     </section>
   )
 }

--- a/frontend/src/panels/ReportPanel.tsx
+++ b/frontend/src/panels/ReportPanel.tsx
@@ -5,8 +5,10 @@ import {
   reportDetailToggleLabel,
   reportUtilizationForDisplay
 } from "../app/helpers"
+import { usePagination } from "../hooks/usePagination"
 import type { Person, ReportGranularity, ReportObjectResult, ReportTableRow } from "../app/types"
 import type { ReportScope } from "../reportColumns"
+import { PaginationControls } from "./PaginationControls"
 
 type ReportPanelProps = {
   reportScope: ReportScope
@@ -59,6 +61,12 @@ export function ReportPanel(props: ReportPanelProps) {
     onToggleReportPeriodDetails
   } = props
   const reportIDSet = new Set(reportIDs)
+  const reportRowsPagination = usePagination(visibleReportRows)
+  const paginatedReportRows = reportRowsPagination.visibleItems
+  const reportColumnCount = 1
+    + (showReportObjectColumn ? 1 : 0)
+    + (showAvailabilityColumns ? 4 : 0)
+    + (showProjectColumns ? 3 : 0)
 
   return (
     <section className="panel">
@@ -138,7 +146,7 @@ export function ReportPanel(props: ReportPanelProps) {
           </tr>
         </thead>
         <tbody>
-          {visibleReportRows.map((row) => {
+          {paginatedReportRows.map((row) => {
             const isExpandableRow = isExpandableReportPeriodRow(row)
             const isExpanded = expandedReportPeriodSet.has(row.periodStart)
             const isOverallocatedReportPerson = reportScope === "person" && isOverallocatedPersonID(row.objectID)
@@ -197,8 +205,28 @@ export function ReportPanel(props: ReportPanelProps) {
               </tr>
             )
           })}
+          {visibleReportRows.length === 0 && (
+            <tr>
+              <td colSpan={reportColumnCount}>No items to display</td>
+            </tr>
+          )}
         </tbody>
       </table>
+      <PaginationControls
+        ariaLabel="Report pagination"
+        currentPage={reportRowsPagination.currentPage}
+        endItemNumber={reportRowsPagination.endItemNumber}
+        hasNextPage={reportRowsPagination.hasNextPage}
+        hasPreviousPage={reportRowsPagination.hasPreviousPage}
+        isPaginated={reportRowsPagination.isPaginated}
+        pageSize={reportRowsPagination.pageSize}
+        startItemNumber={reportRowsPagination.startItemNumber}
+        totalItems={reportRowsPagination.totalItems}
+        totalPages={reportRowsPagination.totalPages}
+        onNextPage={reportRowsPagination.goToNextPage}
+        onPageSizeChange={reportRowsPagination.changePageSize}
+        onPreviousPage={reportRowsPagination.goToPreviousPage}
+      />
     </section>
   )
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -111,6 +111,35 @@ button:disabled {
   gap: 0.5rem;
 }
 
+.pagination-container {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.pagination-summary,
+.pagination-actions,
+.pagination-nav {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.pagination-page-size {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.pagination-page-indicator {
+  color: #334155;
+  font-weight: 600;
+}
+
 .chips {
   display: flex;
   flex-wrap: wrap;
@@ -253,5 +282,17 @@ details > summary {
   td {
     border: 0;
     padding: 0.15rem 0;
+  }
+
+  .pagination-container,
+  .pagination-actions,
+  .pagination-nav {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .pagination-page-size {
+    align-items: stretch;
+    flex-direction: column;
   }
 }


### PR DESCRIPTION
## Summary
- Add reusable frontend pagination hook and controls
- Apply paginated rows and page size selection to all list panels
- Add empty-list states and selected-count summaries
- Cover pagination logic, controls, and person selection across pages

Resolves: #39 

## Validation
- make typecheck
- make test-frontend
- make test-backend

## Notes
- make check currently fails during vulnerability scanning due Go toolchain findings fixed in v1.26.2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a reusable pagination system and a shared pagination control UI for tables, plus empty-state rows and a selectable page-size option including "all".
  * Selection state now persists across pages and page-size changes; responsive pagination UI for mobile.

* **Tests**
  * Added integration and hook tests covering pagination behavior, controls, and selection persistence.

* **Documentation**
  * Updated development prerequisites and CI Go version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->