### PR TITLE
chore(ci): update go toolchain to 1.26.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: 1.26.1
+  GO_VERSION: 1.26.2
   PLATO_VULN_REPORT_ROOT: .cache/vuln/reports
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -98,12 +98,12 @@ Router logic is organized by domain in `backend/internal/httpapi`:
 ### Prerequisites
 
 - Node.js LTS and npm or pnpm
-- Go `1.26.1`
+- Go `1.26.2`
 
 Toolchain policy:
 - Plato enforces the exact Go version from `backend/go.mod` for reproducible local and CI checks
-- `make check` runs `scripts/check_go_toolchain.sh` and fails fast with a clear mismatch message when local Go is not `1.26.1`
-- For containerized local development, use a base image pinned to `golang:1.26.1`
+- `make check` runs `scripts/check_go_toolchain.sh` and fails fast with a clear mismatch message when local Go is not `1.26.2`
+- For containerized local development, use a base image pinned to `golang:1.26.2`
 
 ### Run in development
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,3 +1,3 @@
 module plato/backend
 
-go 1.26.1
+go 1.26.2


### PR DESCRIPTION
## Summary

- Update CI Go version to 1.26.2
- Update backend module Go version to 1.26.2
- Update README toolchain guidance to match

## Validation

- make --warn-undefined-variables check

## Coverage

- Frontend lines: 96.32%
- Backend statements: 91.5%

## Risks

- The root-owned /usr/local/go tree was not replaced because sudo requires a password
- Plain go now resolves to go1.26.2 through persisted Go toolchain config
